### PR TITLE
Make quotation form submission a simple POST

### DIFF
--- a/script.js
+++ b/script.js
@@ -1703,9 +1703,6 @@ async function submitQuotationForm() {
   try {
     const response = await fetch(APPS_SCRIPT_ENDPOINT, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
       body: JSON.stringify(formData)
     });
 


### PR DESCRIPTION
Remove `Content-Type` header from quotation form fetch to enable simple POST and avoid CORS preflight.

This change ensures the browser sends a "simple" POST request, which Google Apps Script accepts without triggering a CORS OPTIONS preflight, resolving previous CORS errors.

---

[Open in Web](https://cursor.com/agents?id=bc-57841063-716b-4713-aa75-6001fb43280d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-57841063-716b-4713-aa75-6001fb43280d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)