### PR TITLE
Check lettings API v3 deployment status

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -7,17 +7,15 @@ const SPREADSHEET_ID = 'YOUR_SPREADSHEET_ID_HERE'; // Replace with your Google S
 const BUSINESS_EMAIL = 'hello@onlinelettingagents.co.uk'; // Replace with your business email
 const SHEET_NAME = 'Quotation Submissions';
 
-// Handle CORS preflight requests
-function doOptions(e) {
+// Handle GET requests (for testing and status check)
+function doGet(e) {
   return ContentService
-    .createTextOutput('')
-    .setMimeType(ContentService.MimeType.TEXT)
-    .setHeaders({
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      'Access-Control-Max-Age': '3600'
-    });
+    .createTextOutput(JSON.stringify({ 
+      status: 'success', 
+      message: 'Quotation API v3 is running',
+      timestamp: new Date().toISOString()
+    }))
+    .setMimeType(ContentService.MimeType.JSON);
 }
 
 function doPost(e) {
@@ -124,26 +122,16 @@ function doPost(e) {
     // Send email notification with CSV attachment
     sendEmailNotification(formData);
     
-    // Return success response with CORS headers
+    // Return success response (no CORS headers needed for simple requests)
     return ContentService
       .createTextOutput(JSON.stringify({ status: 'success', message: 'Quotation submitted successfully' }))
-      .setMimeType(ContentService.MimeType.JSON)
-      .setHeaders({
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type'
-      });
+      .setMimeType(ContentService.MimeType.JSON);
       
   } catch (error) {
     console.error('Error processing quotation submission:', error);
     return ContentService
       .createTextOutput(JSON.stringify({ status: 'error', message: error.toString() }))
-      .setMimeType(ContentService.MimeType.JSON)
-      .setHeaders({
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type'
-      });
+      .setMimeType(ContentService.MimeType.JSON);
   }
 }
 


### PR DESCRIPTION
Add `doGet` function and remove invalid `setHeaders` calls to fix Google Apps Script errors.

The Google Apps Script was failing with "Script function not found: doGet" when accessed directly, and "TypeError: setHeader is not a function" during POST requests due to an incorrect method call on `ContentService.createTextOutput`. This PR resolves both issues by adding the necessary `doGet` handler and removing the unsupported `setHeaders` calls, which are not required for simple form submissions.

---

[Open in Web](https://cursor.com/agents?id=bc-981804bc-c4c9-4e17-adcd-343f900ca478) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-981804bc-c4c9-4e17-adcd-343f900ca478) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)