### PR TITLE
Ensure json payload for apps script

### DIFF
--- a/netlify/functions/quote-proxy.js
+++ b/netlify/functions/quote-proxy.js
@@ -31,21 +31,17 @@ exports.handler = async (event, context) => {
       const jsonData = JSON.parse(event.body);
       console.log('Parsed JSON data:', jsonData);
 
-      // Convert JSON to URL-encoded form data for Apps Script
-      const formBody = new URLSearchParams();
-      Object.keys(jsonData).forEach(key => {
-        formBody.append(key, jsonData[key]);
-      });
+      // Re-stringify the JSON to ensure it's well-formed for Apps Script
+      const jsonBody = JSON.stringify(jsonData);
+      console.log('Re-stringified JSON body:', jsonBody);
 
-      console.log('Converted to form data:', formBody.toString());
-
-      // Forward the request to Google Apps Script as URL-encoded form data
+      // Forward the request to Google Apps Script as JSON
       const response = await fetch(APPS_SCRIPT_URL, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Type': 'application/json',
         },
-        body: formBody.toString(),
+        body: jsonBody,
       });
 
       console.log('Apps Script response status:', response.status);


### PR DESCRIPTION
Ensure Netlify proxy always sends well-formed JSON to Google Apps Script.

The previous proxy was converting the incoming JSON `event.body` into `application/x-www-form-urlencoded` data, which caused parsing errors in Google Apps Script when it expected `application/json` in `e.postData.contents`. This change re-serializes the parsed JSON back into a JSON string and sets the correct `Content-Type` header.

---

[Open in Web](https://cursor.com/agents?id=bc-d2f141db-2217-46b7-9416-3cf3f5f43739) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d2f141db-2217-46b7-9416-3cf3f5f43739) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)