### PR TITLE
Update netlify proxy and front-end to new apps script

### DIFF
--- a/netlify/functions/quote-proxy.js
+++ b/netlify/functions/quote-proxy.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 
 // The Google Apps Script URL
-const APPS_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbyD_wgAwY0i7jnHpbVHRgl3L08Yyvh1VIg5--SdUWrC3vzYxB5qm7_ekggt_KIeSaYz/exec';
+const APPS_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbx-4wLvdbsYBQiKAcSAcfLfT-DzmJGoOFxUdETrtIprb09b0FXDcGQfqFfyy9IkUqzF/exec';
 
 // CORS headers to be included in all responses
 const corsHeaders = {


### PR DESCRIPTION
Update Netlify proxy to point to the new Apps Script Web App (v6) URL.

---

[Open in Web](https://cursor.com/agents?id=bc-d38d7ee3-0d2e-40e9-ba40-a80f3f203c8f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d38d7ee3-0d2e-40e9-ba40-a80f3f203c8f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)