### PR TITLE
Fix quotation form success condition and retry logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -1815,8 +1815,8 @@ async function submitQuotationForm(useMockEndpoint = false) {
       throw new Error('Server response error: Invalid response format received from server.');
     }
     
-    if (data.status !== 'success') {
-      throw new Error(data.message || 'Server returned an error');
+    if (data.result !== 'success') {
+      throw new Error(`Server returned an error: ${data.message || 'unknown error'}`);
     }
 
     return data;


### PR DESCRIPTION
Fixes quotation form's success condition to correctly parse Apps Script response and prevent unnecessary retries.

The form was incorrectly checking `data.status` for success, while the backend Apps Script returns `data.result`. This led to the form treating successful submissions as errors, triggering retries and incorrect UI. This PR updates the check to `data.result` and enhances error messages.

---

[Open in Web](https://cursor.com/agents?id=bc-c731dc26-575a-4fb5-8238-55dac5ced15c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c731dc26-575a-4fb5-8238-55dac5ced15c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)