### PR TITLE
Fix wizard viewport overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3093,9 +3093,9 @@ body.no-scroll {
 /* The viewport containing steps */
 .wizard-viewport{
   position: relative;
-  overflow: visible;
+  overflow-y: auto;
+  max-height: 70vh;
   min-height: 420px;
-  height: auto;
 }
 
 /* Stack all steps on top of each other */


### PR DESCRIPTION
## Summary
- make quotation wizard container scrollable so long steps don't cover navigation buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68851cd4acfc8329aae980a3c505fbe5