### PR TITLE
Fix add on checkbox selection bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -1527,7 +1527,13 @@ function renderPackageOptions() {
 
 // Enhanced Package and Add-on Card Interactions
 function enhancePackageAndAddonCards() {
-  if (!window.location.pathname.endsWith('quotation.html')) return;
+  console.log('enhancePackageAndAddonCards called');
+  // Check if we're on the quotation page by looking for quotation-specific elements
+  if (!document.querySelector('.quote-step')) {
+    console.log('No .quote-step found, returning early');
+    return;
+  }
+  console.log('Found .quote-step, proceeding with enhancement');
   
   // 📦 Style and handle package card interactions (both .package-card and .package-option)
   const packageCards = document.querySelectorAll('.package-card, .package-option');
@@ -1592,10 +1598,16 @@ function enhancePackageAndAddonCards() {
   
   // 🧩 Style and handle add-on card interactions (both .addon-card and .addon-option)
   const addOnCards = document.querySelectorAll('.addon-card, .addon-option');
-  addOnCards.forEach(card => {
+  console.log('Found add-on cards:', addOnCards.length);
+  addOnCards.forEach((card, index) => {
+    console.log(`Processing add-on card ${index}:`, card);
     const checkbox = card.querySelector('input[type="checkbox"]');
     
-    if (!checkbox) return;
+    if (!checkbox) {
+      console.log(`No checkbox found in card ${index}`);
+      return;
+    }
+    console.log(`Checkbox found in card ${index}:`, checkbox);
     
     // Make card focusable
     card.setAttribute('tabindex', '0');
@@ -1604,7 +1616,7 @@ function enhancePackageAndAddonCards() {
     
     // Handle card clicks
     card.addEventListener('click', function(e) {
-      console.log('Addon card clicked:', e.target);
+      console.log('Addon card clicked:', e.target, 'Checkbox found:', !!checkbox);
       // Prevent double-firing if clicking directly on checkbox
       if (e.target.type !== 'checkbox') {
         e.preventDefault();


### PR DESCRIPTION
Fix add-on checkboxes not being selectable by making the page path check more flexible.

The previous path check `window.location.pathname.endsWith('quotation.html')` was too restrictive, preventing the `enhancePackageAndAddonCards` function from executing on pages with different URL structures (e.g., `/` or `/index.html`). This PR updates the check to look for the presence of `.quote-step` elements instead, ensuring the function runs correctly. Debugging logs have also been added to aid in further diagnosis.

---

[Open in Web](https://cursor.com/agents?id=bc-721367ba-b56d-4a5a-be3e-f94032e1f12a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-721367ba-b56d-4a5a-be3e-f94032e1f12a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)